### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM cusspvz/node
+COPY . /app
+RUN npm install -g
+ENTRYPOINT ["node", "bin/www"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '2'
+
+services:
+
+  postgres:
+    image: postgres:9.1
+    volumes:
+      - data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    networks:
+      - freemaill
+    restart: always
+  freemaill:
+    build:
+      context: .
+    ports:
+      - "3000:3000"
+    networks:
+      - freemaill
+    restart: always
+    depends_on:
+      - postgres
+    environment:
+      DATABASE_URL: "postgres://postgres:root@postgres/postgres"
+networks:
+  freemaill:
+    driver: bridge
+volumes:
+  data:


### PR DESCRIPTION
This will allow the app to run in Docker. Simply download install Docker and `docker-compose`, then run `docker-compose up` to build the Freemaill image, start up a PostgreSQL container, then the Freemaill container. Note that this will not bring up a functioning version of Freemaill due to missing table definitions for Postgres, but the necessary files are here for containerization.